### PR TITLE
Fixed building from source when destination has spaces in the path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -69,8 +69,8 @@ util.build = function (url, dest, cb) {
 	var file = path.join(tmpdir, path.basename(url));
 	var tmp = path.join(tmpdir, path.basename(file, '.tar.gz'));
 	var buildScript = './configure --disable-gifview --disable-gifdiff' +
-					  ' --prefix=' + tmp + ' --bindir=' + dest +
-					  ' && ' + 'make install';
+					  ' --prefix="' + tmp + '" --bindir="' + dest +
+					  '" && ' + 'make install';
 
 	try {
 		which.sync('make');


### PR DESCRIPTION
Quick/easy fix (tested on Ubuntu 12.04)
