### PR TITLE
Bump `bin-wrapper` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "bin-build": "^2.0.0",
-    "bin-wrapper": "^2.0.0",
+    "bin-wrapper": "^3.0.0",
     "logalot": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix https://github.com/imagemin/imagemin/issues/68

'could be a brillant idea to release right after this PR :)

(so is optipng-bin)