### PR TITLE
Add support for setting custom binary site

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,10 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/gifsicle-bin/v${pkg.version}/vendor/`;
+const binary_site = process.env.GIFSICLE_BINARY_SITE ||
+                    process.env.npm_config_gifsicle_binary_site ||
+                    'https://raw.githubusercontent.com/imagemin/gifsicle-bin';
+const url = `${binary_site}/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/gifsicle`, 'darwin')


### PR DESCRIPTION
Developers in China have trouble to download binary files from Github directly, this PR supports for setting custom binary site by `GIFSICLE_BINARY_SITE=https://npm.taobao.org/mirrors/gifsicle-bin/ yarn` which will save our lives.

Thanks to [node-sass](https://github.com/sass/node-sass/blob/master/lib/extensions.js#L240) project which inspires me.