### PR TITLE
Bump dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
 	],
 	"dependencies": {
 		"bin-build": "^3.0.0",
-		"bin-wrapper": "^4.0.0",
-		"execa": "^4.0.0",
-		"logalot": "^2.0.0"
+		"bin-wrapper": "^4.1.0",
+		"execa": "^5.0.0",
+		"logalot": "^2.1.0"
 	},
 	"devDependencies": {
 		"ava": "^3.8.0",


### PR DESCRIPTION
My motivation is to update `execa` to its latest major version.

- execa@^5.0.0
- bin-wrapper@^4.1.0
- logalot@^2.1.0