### PR TITLE
remove logalot

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = require('./lib').path();
+module.exports = require('./lib').path(); /* eslint-disable-line import/extensions */

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,17 +1,16 @@
 'use strict';
 const path = require('path');
 const binBuild = require('bin-build');
-const log = require('logalot');
 const bin = require('.');
 
 (async () => {
 	try {
 		await bin.run(['--version']);
-		log.success('gifsicle pre-build test passed successfully');
+		console.log('gifsicle pre-build test passed successfully');
 	} catch (error) {
-		log.warn(error.message);
-		log.warn('gifsicle pre-build test failed');
-		log.info('compiling from source');
+		console.warn(error.message);
+		console.warn('gifsicle pre-build test failed');
+		console.info('compiling from source');
 
 		const config = [
 			'./configure --disable-gifview --disable-gifdiff',
@@ -25,9 +24,9 @@ const bin = require('.');
 				'make install'
 			]);
 
-			log.success('gifsicle built successfully');
+			console.log('gifsicle built successfully');
 		} catch (error) {
-			log.error(error.stack);
+			console.error(error.stack);
 
 			// eslint-disable-next-line unicorn/no-process-exit
 			process.exit(1);

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 	"dependencies": {
 		"bin-build": "^3.0.0",
 		"bin-wrapper": "^4.0.0",
-		"execa": "^5.0.0",
-		"logalot": "^2.0.0"
+		"execa": "^5.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
_not counting dev dependencies_

```diff
- 230 packages
+ 179 packages
```

[logalot](https://www.npmjs.com/package/logalot) was only used in the `postinstall` script and did not add any real value.
Less dependencies means less surface for security issues.

https://www.npmjs.com/advisories/1753