### PR TITLE
Add Github Raw URL for PostInstall URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,10 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/gifsicle-bin/v${pkg.version}/vendor/`;
+const GITHUB_RAW_URL = process.env.GITHUB_RAW_URL
+  ? process.env.GITHUB_RAW_URL
+  : 'https://raw.githubusercontent.com';
+const url = `${GITHUB_RAW_URL}}/imagemin/gifsicle-bin/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/gifsicle`, 'darwin')

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@ You probably want [`imagemin-gifsicle`](https://github.com/imagemin/imagemin-gif
 $ npm install gifsicle
 ```
 
+If you are pulling through your own proxy, you can get `GITHUB_RAW_URL` during install
+to ensure that the prebuilt binary is also pulled through your mirror.
+
 ## Usage
 
 ```js


### PR DESCRIPTION
Allows users to override the github raw url so they can pull through their own proxies instead of reaching out to the internet, failing, and attempting to build from source.