### PR TITLE
Added main field to package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"funding": {
 		"url": "https://github.com/imagemin/gisicle-bin?sponsor=1"
 	},
+	"main": "index.js",
 	"bin": {
 		"gifsicle": "cli.js"
 	},


### PR DESCRIPTION
Removes a deprecation notice when using ES modules.

> (node:5615) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for /[redacted]/node_modules/gifsicle/ resolving the main entry point "index.js", imported from [redacted].
Default "index" lookups for the main are deprecated for ES modules.