### PR TITLE
fix crash at installation on linux platforms with non-intel archs

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -5,6 +5,17 @@ import bin from './index.js';
 
 (async () => {
 	try {
+		// On linux platforms with non-intel architectures, bin-wrapper still
+		// downloads and tries to execute the x86_64 ELF. This results in the
+		// binary file being interpreted as a shell script, which creates a
+		// dangling file that can make npm or yarn crash at installation. This
+		// condition prevents this from happening.
+		//
+		// See https://github.com/imagemin/gifsicle-bin/issues/124#issuecomment-1222646680
+		if (process.platform === 'linux' && !['ia32', 'x64'].includes(process.arch)) {
+			throw Error(`Unsupported platform: ${process.platform}/${process.arch}.`);
+		}
+
 		await bin.run(['--version']);
 		console.log('gifsicle pre-build test passed successfully');
 	} catch (error) {


### PR DESCRIPTION
fixes #124

See https://github.com/imagemin/gifsicle-bin/issues/124#issuecomment-1222646680 for all the details. Note that this bug should probably be addressed in [os-filter-obj](https://github.com/kevva/os-filter-obj/issues/3) / bin-wrapper, but the projects have been unmaintained for a few years.